### PR TITLE
Hide window on startup

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,7 +49,8 @@
         "decorations": false,
         "fullscreen": false,
         "resizable": false,
-        "transparent": true
+        "transparent": true,
+        "visible": false
       }
     ]
   }


### PR DESCRIPTION
Prevents the window from showing on autostart. Can still be toggled from the tray, hotkeys, etc.